### PR TITLE
refactor(prompt): backend assembly and normalize input / 后端拼接与规范化

### DIFF
--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -148,7 +148,7 @@ async fn generate_handler(
     );
 
     // Validate request
-    if request.prompt.is_empty() {
+    if request.prompt.trim().is_empty() {
         return Err(AppError::InvalidRequest(
             "Prompt cannot be empty".to_string(),
         ));

--- a/backend/src/comfyui.rs
+++ b/backend/src/comfyui.rs
@@ -342,15 +342,10 @@ impl ComfyUIClient {
         let vae_name = find_model(&models.vae, &["newbie", "diffusion_pytorch"])
             .unwrap_or_else(|| "newbie-image.safetensors".to_string());
 
-        // Build the prompt prefix for newbie model
-        let positive_prompt = format!(
-            "You are an assistant designed to generate high-quality anime images with the highest degree of image-text alignment based on xml format textual prompts. <Prompt Start>\n{}",
-            request.prompt
-        );
-
-        // Default negative prompt if empty
+        // Build the final prompt on the backend (frontend provides system_prompt + user prompt).
+        let positive_prompt = compose_positive_prompt(request);
         let negative_prompt = if request.negative_prompt.is_empty() {
-            "<danbooru_tags>low_score_rate, worst quality, low quality, bad quality, lowres, low res, pixelated, blurry, blurred, compression artifacts, jpeg artifacts, bad anatomy, worst hands, deformed hands, deformed fingers, deformed feet, deformed toes, extra limbs, extra arms, extra legs, extra fingers, extra digits, extra digit, fused fingers, missing limbs, missing arms, missing fingers, missing toes, wrong hands, ugly hands, ugly fingers, twisted hands, flexible deformity, conjoined, disembodied, text, watermark, signature, logo, ugly, worst, very displeasing, displeasing, error, doesnotexist, unfinished, poorly drawn face, poorly drawn hands, poorly drawn feet, artistic error, bad proportions, bad perspective, out of frame, ai-generated, ai-assisted, stable diffusion, overly saturated, overly vivid, cross-eye, expressionless, scan, sketch, monochrome, simple background, abstract, sequence, lineup, 2koma, 4koma, microsoft paint \\(medium\\), artifacts, adversarial noise, has bad revision, resized, image sample,low_aesthetic</danbooru_tags>".to_string()
+            String::new()
         } else {
             format!("<danbooru_tags>{}</danbooru_tags>", request.negative_prompt)
         };
@@ -499,6 +494,73 @@ impl ComfyUIClient {
 
         workflow
     }
+}
+
+fn compose_positive_prompt(request: &GenerateRequest) -> String {
+    let user_prompt = normalize_prompt(&request.prompt);
+    let system_prompt = request
+        .system_prompt
+        .as_deref()
+        .unwrap_or("")
+        .trim();
+
+    if system_prompt.is_empty() {
+        format!("<Prompt Start>,{}", user_prompt)
+    } else {
+        format!("{}\n<Prompt Start>,{}", system_prompt, user_prompt)
+    }
+}
+
+fn normalize_prompt(raw: &str) -> String {
+    let mut s = raw;
+    if let Some(stripped) = s.strip_prefix('\u{feff}') {
+        s = stripped;
+    }
+
+    let s = s.replace("\r\n", "\n").replace('\r', "\n");
+    let mut s = s.trim_start();
+
+    // If the user already pasted a Prompt Start header, remove it to avoid duplication.
+    let prompt_start = "<prompt start>";
+    if s.len() >= prompt_start.len() && s[..prompt_start.len()].eq_ignore_ascii_case(prompt_start)
+    {
+        s = s[prompt_start.len()..].trim_start_matches(|c: char| {
+            c.is_whitespace() || c == ',' || c == ':'
+        });
+    }
+
+    let s = s.trim();
+    if s.is_empty() {
+        return String::new();
+    }
+
+    let mut lines = Vec::new();
+    for line in s.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let mut out = String::with_capacity(trimmed.len());
+        let mut prev_space = false;
+        for ch in trimmed.chars() {
+            if ch.is_whitespace() {
+                if !prev_space {
+                    out.push(' ');
+                    prev_space = true;
+                }
+            } else {
+                out.push(ch);
+                prev_space = false;
+            }
+        }
+
+        if !out.is_empty() {
+            lines.push(out);
+        }
+    }
+
+    lines.join("\n")
 }
 
 /// Generate a random seed

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -78,15 +78,17 @@ async fn main() {
     let url = format!("http://localhost:{}", port);
     tracing::info!("Server running at {}", url);
 
-    // Open browser
-    #[cfg(target_os = "windows")]
-    let _ = std::process::Command::new("cmd")
-        .args(["/C", "start", &url])
-        .spawn();
-    #[cfg(target_os = "macos")]
-    let _ = std::process::Command::new("open").arg(&url).spawn();
-    #[cfg(target_os = "linux")]
-    let _ = std::process::Command::new("xdg-open").arg(&url).spawn();
+    // Open browser only in release builds (skip during dev)
+    if cfg!(not(debug_assertions)) {
+        #[cfg(target_os = "windows")]
+        let _ = std::process::Command::new("cmd")
+            .args(["/C", "start", &url])
+            .spawn();
+        #[cfg(target_os = "macos")]
+        let _ = std::process::Command::new("open").arg(&url).spawn();
+        #[cfg(target_os = "linux")]
+        let _ = std::process::Command::new("xdg-open").arg(&url).spawn();
+    }
 
     axum::serve(listener, app).await.expect("Server crashed");
 }

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -10,6 +10,8 @@ use std::collections::HashMap;
 pub struct GenerateRequest {
     /// Positive prompt text
     pub prompt: String,
+    /// Optional system prompt to prefix before user prompt
+    pub system_prompt: Option<String>,
     /// Negative prompt text
     #[serde(default)]
     pub negative_prompt: String,

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,13 +1,13 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>frontend</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
+    <head>
+        <meta charset="UTF-8" />
+        <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Newbie-Image Generator</title>
+    </head>
+    <body>
+        <div id="root"></div>
+        <script type="module" src="/src/main.tsx"></script>
+    </body>
 </html>

--- a/frontend/src/components/ImageGenerator.tsx
+++ b/frontend/src/components/ImageGenerator.tsx
@@ -255,12 +255,6 @@ export function ImageGenerator() {
   }, [checkComfyUIHealth]);
 
   // 构建最终 prompt
-  const buildFinalPrompt = (): string => {
-    const userPrompt =
-      promptMode === "normal" ? params.prompt : structuredPrompt;
-    return `${systemPrompt}\n<Prompt Start>,${userPrompt}`;
-  };
-
   const handleGenerate = async () => {
     const userPrompt =
       promptMode === "normal" ? params.prompt : structuredPrompt;
@@ -274,11 +268,10 @@ export function ImageGenerator() {
     setError(null);
     setPreviewImage(null);
 
-    const finalPrompt = buildFinalPrompt();
-
     try {
       const response = await api.generate({
-        prompt: finalPrompt,
+        prompt: userPrompt,
+        system_prompt: systemPrompt,
         negative_prompt: params.negativePrompt,
         width: params.width,
         height: params.height,

--- a/frontend/src/components/XMLImport.tsx
+++ b/frontend/src/components/XMLImport.tsx
@@ -37,7 +37,9 @@ interface XMLImportProps {
 }
 
 function parseTag(xml: string, tag: string): string {
-  const match = xml.match(new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`));
+  const match = xml.match(
+    new RegExp(`<${tag}\\s*>([\\s\\S]*?)</${tag}\\s*>`, "i"),
+  );
   return match ? match[1].trim() : "";
 }
 
@@ -101,13 +103,29 @@ export function parseXML(xml: string): ParsedXML {
   };
 
   // 2. 提取自然语言：移除所有已识别的结构化内容，剩余的就是自然语言
-  const caption = content
+  let caption = content
     // 移除所有 character 块
     .replace(/<character[_ ]\d+>[\s\S]*?<\/character[_ ]\d+>/gi, "")
     // 移除 general_tags 块
     .replace(/<general_tags>[\s\S]*?<\/general_tags>/gi, "")
     .replace(/<general tags>[\s\S]*?<\/general tags>/gi, "")
     // 清理多余空白
+    .trim();
+
+  const captionFromTag = parseTag(content, "caption");
+  const contentWithoutCaption = content.replace(
+    /<caption[\s\S]*?>[\s\S]*?<\/caption>/gi,
+    "",
+  );
+
+  caption = (captionFromTag || contentWithoutCaption)
+    // 移除 <characters> 包裹层
+    .replace(/<\/?characters[^>]*>/gi, "")
+    // 移除所有 character 块
+    .replace(/<character[_ ]\d+>[\s\S]*?<\/character[_ ]\d+>/gi, "")
+    // 移除 general_tags 块
+    .replace(/<general_tags>[\s\S]*?<\/general_tags>/gi, "")
+    .replace(/<general tags>[\s\S]*?<\/general tags>/gi, "")
     .trim();
 
   return {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -2,6 +2,7 @@
 
 export interface GenerateRequest {
   prompt: string;
+  system_prompt?: string;
   negative_prompt?: string;
   width?: number;
   height?: number;


### PR DESCRIPTION
## Summary (EN)
- Move prompt assembly to backend and normalize user input (trim/whitespace/duplicate <Prompt Start> handling).
- Pass `system_prompt` explicitly and validate non-empty prompt using trim.
- Fix XML import caption extraction to avoid leaking wrapper tags.
- Open browser only in release builds.

## 说明（中文）
- 提示词拼接移到后端，并对用户输入做规范化（空白/换行/重复 <Prompt Start> 处理）。
- 显式传递 `system_prompt`，并使用 trim 校验空提示词。
- 修复 XML 导入的自然语言提取，避免 `<characters>` 等标签残留。
- 仅在 release 构建自动打开浏览器。

## Tests / 测试
- Not run (not requested) / 未运行（未要求）

## Issues / 关联问题
- N/A

## Screenshots / 截图
- N/A