### PR TITLE
chore(security): local-only defaults / 本地默认安全收紧

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,11 @@ bun run dev
 编辑 `backend/.env`：
 
 ```env
-HOST=0.0.0.0
+HOST=127.0.0.1
 PORT=3000
 COMFYUI_HOST=127.0.0.1
 COMFYUI_PORT=8188
+ALLOW_REMOTE_COMFYUI=false
 ```
 
 ## 技术栈

--- a/README_EN.md
+++ b/README_EN.md
@@ -113,10 +113,11 @@ bun run dev
 Edit `backend/.env`:
 
 ```env
-HOST=0.0.0.0
+HOST=127.0.0.1
 PORT=3000
 COMFYUI_HOST=127.0.0.1
 COMFYUI_PORT=8188
+ALLOW_REMOTE_COMFYUI=false
 ```
 
 ## Tech Stack

--- a/README_JP.md
+++ b/README_JP.md
@@ -110,10 +110,11 @@ bun run dev
 `backend/.env` を編集：
 
 ```env
-HOST=0.0.0.0
+HOST=127.0.0.1
 PORT=3000
 COMFYUI_HOST=127.0.0.1
 COMFYUI_PORT=8188
+ALLOW_REMOTE_COMFYUI=false
 ```
 
 ## 技術スタック

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,10 +1,12 @@
-# Backend Server Configuration
-HOST=0.0.0.0
+# Backend Server Configuration (local-only by default)
+HOST=127.0.0.1
 PORT=3000
 
 # ComfyUI Server Configuration
 COMFYUI_HOST=127.0.0.1
 COMFYUI_PORT=8188
+# Allow remote ComfyUI URLs (SSRF risk if enabled)
+ALLOW_REMOTE_COMFYUI=false
 
 # Public base URL for backend
 PUBLIC_BASE_URL=http://localhost:3000

--- a/backend/README.md
+++ b/backend/README.md
@@ -45,10 +45,11 @@ cargo build --release
 复制 `.env.example` 为 `.env`：
 
 ```env
-HOST=0.0.0.0
+HOST=127.0.0.1
 PORT=3000
 COMFYUI_HOST=127.0.0.1
 COMFYUI_PORT=8188
+ALLOW_REMOTE_COMFYUI=false
 PUBLIC_BASE_URL=http://localhost:3000
 CORS_ORIGINS=http://localhost:3001,http://127.0.0.1:3001
 RUST_LOG=info,tower_http=debug

--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -6,12 +6,15 @@ use axum::{
 };
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use futures::{SinkExt, StreamExt};
+use reqwest::Url;
 use serde::Deserialize;
+use std::sync::Arc;
 use tokio::sync::broadcast;
 use tower_http::services::{ServeDir, ServeFile};
 use uuid::Uuid;
 
 use crate::comfyui::ComfyUIClient;
+use crate::config::Config;
 use crate::error::{AppError, AppResult};
 use crate::models::*;
 
@@ -21,6 +24,7 @@ pub struct AppState {
     pub comfyui: ComfyUIClient,
     pub event_tx: broadcast::Sender<String>,
     pub comfyui_client_id: String,
+    pub config: Arc<Config>,
 }
 
 /// Create the API router
@@ -61,6 +65,55 @@ pub fn create_router(state: AppState) -> Router {
         .fallback_service(serve_dir)
 }
 
+fn normalize_comfyui_url(raw: &str, allow_remote: bool) -> AppResult<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(AppError::InvalidRequest(
+            "ComfyUI URL cannot be empty".to_string(),
+        ));
+    }
+
+    let candidate = trimmed.trim_end_matches('/');
+    let parsed = if candidate.starts_with("http://") || candidate.starts_with("https://") {
+        Url::parse(candidate)
+    } else {
+        Url::parse(&format!("http://{}", candidate))
+    }
+    .map_err(|_| AppError::InvalidRequest("Invalid ComfyUI URL".to_string()))?;
+
+    match parsed.scheme() {
+        "http" | "https" => {}
+        _ => {
+            return Err(AppError::InvalidRequest(
+                "ComfyUI URL must start with http:// or https://".to_string(),
+            ))
+        }
+    }
+
+    if parsed.path() != "" && parsed.path() != "/" {
+        return Err(AppError::InvalidRequest(
+            "ComfyUI URL must not include a path".to_string(),
+        ));
+    }
+
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| AppError::InvalidRequest("ComfyUI URL missing host".to_string()))?;
+
+    if !allow_remote && !is_local_host(host) {
+        return Err(AppError::InvalidRequest(
+            "Remote ComfyUI URLs are disabled. Set ALLOW_REMOTE_COMFYUI=true to allow."
+                .to_string(),
+        ));
+    }
+
+    Ok(parsed.as_str().trim_end_matches('/').to_string())
+}
+
+fn is_local_host(host: &str) -> bool {
+    matches!(host, "localhost" | "127.0.0.1" | "::1")
+}
+
 // ============================================================================
 // Health and Status Handlers
 // ============================================================================
@@ -79,8 +132,11 @@ struct TestComfyUIRequest {
     url: String,
 }
 
-async fn test_comfyui_handler(Json(request): Json<TestComfyUIRequest>) -> Json<serde_json::Value> {
-    let url = request.url.trim_end_matches('/');
+async fn test_comfyui_handler(
+    State(state): State<AppState>,
+    Json(request): Json<TestComfyUIRequest>,
+) -> AppResult<Json<serde_json::Value>> {
+    let url = normalize_comfyui_url(&request.url, state.config.allow_remote_comfyui)?;
     let test_url = format!("{}/system_stats", url);
 
     let client = reqwest::Client::builder()
@@ -88,10 +144,12 @@ async fn test_comfyui_handler(Json(request): Json<TestComfyUIRequest>) -> Json<s
         .build()
         .unwrap();
 
-    match client.get(&test_url).send().await {
-        Ok(resp) if resp.status().is_success() => Json(serde_json::json!({ "success": true })),
-        _ => Json(serde_json::json!({ "success": false })),
-    }
+    let success = match client.get(&test_url).send().await {
+        Ok(resp) if resp.status().is_success() => true,
+        _ => false,
+    };
+
+    Ok(Json(serde_json::json!({ "success": success })))
 }
 
 async fn get_comfyui_url_handler(State(state): State<AppState>) -> Json<serde_json::Value> {
@@ -107,11 +165,11 @@ struct SetComfyUIUrlRequest {
 async fn set_comfyui_url_handler(
     State(state): State<AppState>,
     Json(request): Json<SetComfyUIUrlRequest>,
-) -> Json<serde_json::Value> {
-    let url = request.url.trim_end_matches('/');
-    state.comfyui.set_url(url).await;
+) -> AppResult<Json<serde_json::Value>> {
+    let url = normalize_comfyui_url(&request.url, state.config.allow_remote_comfyui)?;
+    state.comfyui.set_url(&url).await;
     tracing::info!("ComfyUI URL updated to: {}", url);
-    Json(serde_json::json!({ "success": true, "url": url }))
+    Ok(Json(serde_json::json!({ "success": true, "url": url })))
 }
 
 async fn status_handler(State(state): State<AppState>) -> AppResult<Json<serde_json::Value>> {

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -34,6 +34,8 @@ pub struct Config {
     pub public_base_url: String,
     /// Allowed CORS origins
     pub cors_origins: Vec<String>,
+    /// Allow remote ComfyUI URLs (SSRF risk if enabled)
+    pub allow_remote_comfyui: bool,
 }
 
 impl Config {
@@ -41,7 +43,7 @@ impl Config {
     pub fn from_env() -> Self {
         dotenvy::dotenv().ok();
 
-        let host = env::var("HOST").unwrap_or_else(|_| "0.0.0.0".to_string());
+        let host = env::var("HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
         let port = env::var("PORT")
             .unwrap_or_else(|_| "3000".to_string())
             .parse()
@@ -62,12 +64,17 @@ impl Config {
             .map(|s| s.trim().to_string())
             .collect();
 
+        let allow_remote_comfyui = env::var("ALLOW_REMOTE_COMFYUI")
+            .unwrap_or_else(|_| "false".to_string())
+            .to_lowercase();
+
         Self {
             host,
             port,
             comfyui: Arc::new(RwLock::new(ComfyUIConfig::new(&comfyui_url))),
             public_base_url,
             cors_origins,
+            allow_remote_comfyui: matches!(allow_remote_comfyui.as_str(), "1" | "true" | "yes"),
         }
     }
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -7,7 +7,8 @@ mod models;
 use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio::sync::broadcast;
-use tower_http::cors::{Any, CorsLayer};
+use axum::http::HeaderValue;
+use tower_http::cors::{AllowOrigin, Any, CorsLayer};
 use tower_http::trace::TraceLayer;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -42,13 +43,23 @@ async fn main() {
         comfyui: comfyui.clone(),
         event_tx: event_tx.clone(),
         comfyui_client_id: comfyui_client_id.clone(),
+        config: config.clone(),
     };
 
-    // Configure CORS
-    let cors = CorsLayer::new()
-        .allow_origin(Any)
-        .allow_methods(Any)
-        .allow_headers(Any);
+    // Configure CORS (local-only by default)
+    let origin_list: Vec<HeaderValue> = config
+        .cors_origins
+        .iter()
+        .filter_map(|origin| origin.parse().ok())
+        .collect();
+
+    let cors = if origin_list.is_empty() {
+        CorsLayer::new()
+    } else {
+        CorsLayer::new().allow_origin(AllowOrigin::list(origin_list))
+    }
+    .allow_methods(Any)
+    .allow_headers(Any);
 
     // Create router with middleware
     let app = create_router(state)


### PR DESCRIPTION
## Summary (EN)
- Default backend binding to 127.0.0.1 for local-only use.
- Enforce CORS allowlist from `CORS_ORIGINS` instead of allowing any origin.
- Restrict ComfyUI URL changes/tests to localhost unless `ALLOW_REMOTE_COMFYUI=true`.
- Update docs/env examples to reflect local-safe defaults.

## 说明（中文）
- 默认仅绑定 127.0.0.1（本地使用）。
- CORS 使用 `CORS_ORIGINS` 白名单，不再全放开。
- ComfyUI 地址仅允许本机，除非设置 `ALLOW_REMOTE_COMFYUI=true`。
- 更新文档与示例环境变量为本地安全默认值。

## Tests / 测试
- Not run (config-only changes) / 未运行（配置变更）

## Issues / 关联问题
- N/A

## Screenshots / 截图
- N/A