### PR TITLE
fix(frontend): fetch images via backend api

### DIFF
--- a/frontend/src/components/GeneratedImages.tsx
+++ b/frontend/src/components/GeneratedImages.tsx
@@ -9,7 +9,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import type { ImageResult } from "@/lib/types";
-import { getImageUrl } from "@/lib/config";
+import { api } from "@/lib/api";
 
 interface GeneratedImagesProps {
   images: ImageResult[];
@@ -23,7 +23,7 @@ export function GeneratedImages({
   const [selectedIndex, setSelectedIndex] = useState<number>(0);
 
   const getUrl = (image: ImageResult) =>
-    getImageUrl(image.filename, image.subfolder, image.type);
+    api.getImageUrl(image.filename, image.subfolder, image.type);
 
   const handleDownload = async (image: ImageResult) => {
     try {

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -16,15 +16,6 @@ export const setComfyUIUrl = (url: string): void => {
   localStorage.setItem(COMFYUI_URL_KEY, trimTrailingSlash(url));
 };
 
-export const getImageUrl = (
-  filename: string,
-  subfolder: string,
-  type: string,
-): string => {
-  const base = getComfyUIUrl();
-  return `${base}/view?filename=${encodeURIComponent(filename)}&subfolder=${encodeURIComponent(subfolder)}&type=${encodeURIComponent(type)}`;
-};
-
 export const resolveApiBase = () => {
   const apiBase = import.meta.env.VITE_API_BASE_URL?.trim();
   if (apiBase) {


### PR DESCRIPTION
## Summary (EN)
- Route generated image fetch/download through backend `/api/images`.
- Remove the ComfyUI direct image URL helper.

## 说明（中文）
- 生成图片与下载改为走后端 `/api/images`。
- 移除直连 ComfyUI 的图片 URL 工具函数。

## Tests / 测试
- `cargo check` (pass)
- `bun run build` (fails: Error: spawn EPERM while loading Vite config / esbuild)

## Issues / 关联问题
- N/A

## Screenshots / 截图
- N/A