### PR TITLE
feat(frontend): backend-owned comfyui url

### DIFF
--- a/frontend/src/hooks/useComfyUIConnection.ts
+++ b/frontend/src/hooks/useComfyUIConnection.ts
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useState } from "react";
 import { api } from "@/lib/api";
-import { getComfyUIUrl, setComfyUIUrl } from "@/lib/config";
+const DEFAULT_COMFYUI_URL = "http://127.0.0.1:8188";
 
 export type ConnectionTestResult = "success" | "error" | null;
 
 export function useComfyUIConnection() {
-  const [comfyuiUrl, setComfyuiUrlState] = useState(getComfyUIUrl());
+  const [comfyuiUrl, setComfyuiUrlState] = useState(DEFAULT_COMFYUI_URL);
   const [comfyuiConnected, setComfyuiConnected] = useState<boolean | null>(
     null,
   );
@@ -21,25 +21,20 @@ export function useComfyUIConnection() {
     }
   }, []);
 
-  const syncComfyUIUrl = useCallback(
+  const updateComfyUIUrl = useCallback(
     async (url: string) => {
       setComfyuiUrlState(url);
-      setComfyUIUrl(url);
       try {
-        await api.setComfyUIUrl(url);
+        const response = await api.setComfyUIUrl(url);
+        if (response.url) {
+          setComfyuiUrlState(response.url);
+        }
       } catch {
         // Backend might not be available yet
       }
-    },
-    [],
-  );
-
-  const updateComfyUIUrl = useCallback(
-    async (url: string) => {
-      await syncComfyUIUrl(url);
       await checkComfyUIHealth();
     },
-    [checkComfyUIHealth, syncComfyUIUrl],
+    [checkComfyUIHealth],
   );
 
   const testConnection = useCallback(async () => {
@@ -64,8 +59,18 @@ export function useComfyUIConnection() {
   }, [comfyuiUrl, updateComfyUIUrl]);
 
   useEffect(() => {
-    syncComfyUIUrl(getComfyUIUrl());
-  }, [syncComfyUIUrl]);
+    const fetchUrl = async () => {
+      try {
+        const response = await api.getComfyUIUrl();
+        if (response.url) {
+          setComfyuiUrlState(response.url);
+        }
+      } catch {
+        // Backend might not be available yet
+      }
+    };
+    fetchUrl();
+  }, []);
 
   useEffect(() => {
     checkComfyUIHealth();

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -1,21 +1,5 @@
 const trimTrailingSlash = (value: string) => value.replace(/\/+$/, "");
 
-const COMFYUI_URL_KEY = "comfyui_url";
-const DEFAULT_COMFYUI_URL = "http://127.0.0.1:8188";
-
-export const getComfyUIUrl = (): string => {
-  const url = localStorage.getItem(COMFYUI_URL_KEY) || DEFAULT_COMFYUI_URL;
-  // Ensure URL has protocol
-  if (url && !url.startsWith("http://") && !url.startsWith("https://")) {
-    return `http://${url}`;
-  }
-  return url;
-};
-
-export const setComfyUIUrl = (url: string): void => {
-  localStorage.setItem(COMFYUI_URL_KEY, trimTrailingSlash(url));
-};
-
 export const resolveApiBase = () => {
   const apiBase = import.meta.env.VITE_API_BASE_URL?.trim();
   if (apiBase) {


### PR DESCRIPTION
## Summary (EN)
- Load ComfyUI URL from backend on mount.
- Remove localStorage persistence; keep backend as source of truth.

## 说明（中文）
- 启动时从后端读取 ComfyUI URL。
- 移除 localStorage 持久化，后端作为唯一来源。

## Tests / 测试
- `cargo check` (pass)
- `bun run build` (fails: Error: spawn EPERM while loading Vite config / esbuild)

## Issues / 关联问题
- N/A

## Screenshots / 截图
- N/A