### PR TITLE
fix(images): support nested filenames and encode params

### DIFF
--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -56,7 +56,7 @@ pub fn create_router(state: AppState) -> Router {
         .route("/api/queue", get(queue_handler))
         .route("/api/history/{prompt_id}", get(history_handler))
         // Image endpoints
-        .route("/api/images/{filename}", get(image_handler))
+        .route("/api/images/*filename", get(image_handler))
         // Control endpoints
         .route("/api/interrupt", post(interrupt_handler))
         .route("/api/clear", post(clear_handler))
@@ -112,11 +112,7 @@ fn normalize_comfyui_url(raw: &str, policy: ComfyUIUrlPolicy) -> AppResult<Strin
     Ok(parsed.as_str().trim_end_matches('/').to_string())
 }
 
-fn is_allowed_comfyui_host(
-    host: &str,
-    port: Option<u16>,
-    policy: ComfyUIUrlPolicy,
-) -> bool {
+fn is_allowed_comfyui_host(host: &str, port: Option<u16>, policy: ComfyUIUrlPolicy) -> bool {
     if policy == ComfyUIUrlPolicy::Any {
         return true;
     }
@@ -159,12 +155,7 @@ fn is_lan_host(host: &str, port: u16) -> bool {
 
 fn is_lan_ip(ip: IpAddr) -> bool {
     match ip {
-        IpAddr::V4(v4) => {
-            v4.is_private()
-                || v4.is_loopback()
-                || v4.is_link_local()
-                || is_cgnat(v4)
-        }
+        IpAddr::V4(v4) => v4.is_private() || v4.is_loopback() || v4.is_link_local() || is_cgnat(v4),
         IpAddr::V6(v6) => v6.is_loopback() || v6.is_unique_local() || v6.is_unicast_link_local(),
     }
 }

--- a/backend/src/comfyui.rs
+++ b/backend/src/comfyui.rs
@@ -1,7 +1,7 @@
 use crate::config::Config;
 use crate::error::{AppError, AppResult};
 use crate::models::*;
-use reqwest::Client;
+use reqwest::{Client, Url};
 use serde_json::{json, Value};
 use std::sync::Arc;
 
@@ -196,15 +196,14 @@ impl ComfyUIClient {
         subfolder: &str,
         image_type: &str,
     ) -> AppResult<Vec<u8>> {
-        let url = format!(
-            "{}/view?filename={}&subfolder={}&type={}",
-            self.base_url().await,
-            filename,
-            subfolder,
-            image_type
-        );
+        let mut url = Url::parse(&format!("{}/view", self.base_url().await))
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+        url.query_pairs_mut()
+            .append_pair("filename", filename)
+            .append_pair("subfolder", subfolder)
+            .append_pair("type", image_type);
 
-        let resp = self.client.get(&url).send().await?;
+        let resp = self.client.get(url).send().await?;
 
         if !resp.status().is_success() {
             return Err(AppError::ComfyUIApi(format!(
@@ -498,11 +497,7 @@ impl ComfyUIClient {
 
 fn compose_positive_prompt(request: &GenerateRequest) -> String {
     let user_prompt = normalize_prompt(&request.prompt);
-    let system_prompt = request
-        .system_prompt
-        .as_deref()
-        .unwrap_or("")
-        .trim();
+    let system_prompt = request.system_prompt.as_deref().unwrap_or("").trim();
 
     if system_prompt.is_empty() {
         format!("<Prompt Start>,{}", user_prompt)
@@ -522,11 +517,9 @@ fn normalize_prompt(raw: &str) -> String {
 
     // If the user already pasted a Prompt Start header, remove it to avoid duplication.
     let prompt_start = "<prompt start>";
-    if s.len() >= prompt_start.len() && s[..prompt_start.len()].eq_ignore_ascii_case(prompt_start)
-    {
-        s = s[prompt_start.len()..].trim_start_matches(|c: char| {
-            c.is_whitespace() || c == ',' || c == ':'
-        });
+    if s.len() >= prompt_start.len() && s[..prompt_start.len()].eq_ignore_ascii_case(prompt_start) {
+        s = s[prompt_start.len()..]
+            .trim_start_matches(|c: char| c.is_whitespace() || c == ',' || c == ':');
     }
 
     let s = s.trim();

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -70,7 +70,10 @@ export const api = {
 
   // Get image URL
   getImageUrl(filename: string, subfolder = "", type = "output"): string {
-    return `${API_BASE}/images/${filename}?subfolder=${subfolder}&type=${type}`;
+    const encodedFilename = encodeURIComponent(filename);
+    const encodedSubfolder = encodeURIComponent(subfolder);
+    const encodedType = encodeURIComponent(type);
+    return `${API_BASE}/images/${encodedFilename}?subfolder=${encodedSubfolder}&type=${encodedType}`;
   },
 
   // Interrupt current generation


### PR DESCRIPTION
## Summary (CN)
- 修复 /api/images 路由支持包含子目录的文件名，避免命中失败回退到前端
- 后端请求 ComfyUI 图片时对 filename/subfolder/type 做 URL 编码，避免特殊字符导致失败
- 前端生成图片 URL 对参数编码，保证新标签/下载稳定

## Summary (EN)
- Allow /api/images to accept nested filenames so image requests don’t fall through to the frontend.
- Encode image query params when proxying to ComfyUI to avoid failures with special characters.
- Encode image URL params on the frontend for stable new-tab/download behavior.

## Testing (CN)
- `cargo build --release`
- `bun run build`

## Testing (EN)
- `cargo build --release`
- `bun run build`

## Risk (CN)
- Low

## Risk (EN)
- Low