### PR TITLE
feat(backend): add lora support to workflow

### DIFF
--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -18,6 +18,7 @@ use crate::comfyui::ComfyUIClient;
 use crate::config::{ComfyUIUrlPolicy, Config};
 use crate::error::{AppError, AppResult};
 use crate::models::*;
+use crate::services::prompt_optimizer::PromptOptimizer;
 
 /// Application state shared across handlers
 #[derive(Clone)]
@@ -25,6 +26,7 @@ pub struct AppState {
     pub comfyui: ComfyUIClient,
     pub event_tx: broadcast::Sender<String>,
     pub comfyui_client_id: String,
+    pub prompt_optimizer: PromptOptimizer,
     pub config: Arc<Config>,
 }
 
@@ -53,6 +55,7 @@ pub fn create_router(state: AppState) -> Router {
         )
         // Generation endpoints
         .route("/api/generate", post(generate_handler))
+        .route("/api/prompt/optimize", post(optimize_prompt_handler))
         .route("/api/queue", get(queue_handler))
         .route("/api/history/{prompt_id}", get(history_handler))
         // Image endpoints
@@ -65,6 +68,18 @@ pub fn create_router(state: AppState) -> Router {
         .with_state(state)
         // Fallback to serve static files (frontend)
         .fallback_service(serve_dir)
+}
+
+// ============================================================================
+// Prompt Optimization Handlers
+// ============================================================================
+
+async fn optimize_prompt_handler(
+    State(state): State<AppState>,
+    Json(request): Json<OptimizePromptRequest>,
+) -> AppResult<Json<OptimizePromptResponse>> {
+    let resp = state.prompt_optimizer.optimize(request).await?;
+    Ok(Json(resp))
 }
 
 fn normalize_comfyui_url(raw: &str, policy: ComfyUIUrlPolicy) -> AppResult<String> {

--- a/backend/src/comfyui.rs
+++ b/backend/src/comfyui.rs
@@ -412,14 +412,6 @@ impl ComfyUIClient {
                 "class_type": "PreviewImage",
                 "_meta": {"title": "预览图像"}
             },
-            "51": {
-                "inputs": {
-                    "multiplier": 0.9,
-                    "model": ["54", 0]
-                },
-                "class_type": "RescaleCFG",
-                "_meta": {"title": "缩放CFG"}
-            },
             "54": {
                 "inputs": {
                     "unet_name": unet_name,
@@ -437,23 +429,55 @@ impl ComfyUIClient {
                 },
                 "class_type": "DualCLIPLoader",
                 "_meta": {"title": "双CLIP加载器"}
-            },
-            "59": {
-                "inputs": {
-                    "text": negative_prompt,
-                    "clip": ["58", 0]
-                },
-                "class_type": "CLIPTextEncode",
-                "_meta": {"title": "CLIP文本编码器"}
-            },
-            "61": {
-                "inputs": {
-                    "text": positive_prompt,
-                    "clip": ["58", 0]
-                },
-                "class_type": "CLIPTextEncode",
-                "_meta": {"title": "CLIP文本编码器"}
             }
+        });
+
+        // Build LoRA chain and determine final model/clip outputs
+        let mut model_output = json!(["54", 0]); // Start from UNETLoader
+        let mut clip_output = json!(["58", 0]);  // Start from DualCLIPLoader
+
+        for (i, lora) in request.loras.iter().enumerate() {
+            let node_id = format!("{}", 200 + i);
+            workflow[&node_id] = json!({
+                "inputs": {
+                    "lora_name": lora.name,
+                    "strength": lora.strength,
+                    "model": model_output,
+                    "clip": clip_output
+                },
+                "class_type": "NewBieLoraLoader",
+                "_meta": {"title": format!("LoRA加载器 {}", i + 1)}
+            });
+            model_output = json!([node_id, 0]);
+            clip_output = json!([node_id, 1]);
+        }
+
+        // RescaleCFG uses final model output
+        workflow["51"] = json!({
+            "inputs": {
+                "multiplier": 0.9,
+                "model": model_output
+            },
+            "class_type": "RescaleCFG",
+            "_meta": {"title": "缩放CFG"}
+        });
+
+        // CLIPTextEncode nodes use final clip output
+        workflow["59"] = json!({
+            "inputs": {
+                "text": negative_prompt,
+                "clip": clip_output
+            },
+            "class_type": "CLIPTextEncode",
+            "_meta": {"title": "CLIP文本编码器"}
+        });
+        workflow["61"] = json!({
+            "inputs": {
+                "text": positive_prompt,
+                "clip": clip_output
+            },
+            "class_type": "CLIPTextEncode",
+            "_meta": {"title": "CLIP文本编码器"}
         });
 
         // Add HiFix nodes if enabled

--- a/backend/src/comfyui.rs
+++ b/backend/src/comfyui.rs
@@ -438,10 +438,13 @@ impl ComfyUIClient {
 
         for (i, lora) in request.loras.iter().enumerate() {
             let node_id = format!("{}", 200 + i);
+            // ComfyUI on Windows expects backslashes in lora paths
+            let lora_name = lora.name.replace("/", "\\");
             workflow[&node_id] = json!({
                 "inputs": {
-                    "lora_name": lora.name,
+                    "lora_name": lora_name,
                     "strength": lora.strength,
+                    "enabled": true,
                     "model": model_output,
                     "clip": clip_output
                 },

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -3,11 +3,12 @@ mod comfyui;
 mod config;
 mod error;
 mod models;
+mod services;
 
+use axum::http::HeaderValue;
 use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio::sync::broadcast;
-use axum::http::HeaderValue;
 use tower_http::cors::{AllowOrigin, Any, CorsLayer};
 use tower_http::trace::TraceLayer;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -15,6 +16,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use crate::api::{create_router, start_comfyui_listener, AppState};
 use crate::comfyui::ComfyUIClient;
 use crate::config::Config;
+use crate::services::prompt_optimizer::PromptOptimizer;
 
 #[tokio::main]
 async fn main() {
@@ -43,6 +45,7 @@ async fn main() {
         comfyui: comfyui.clone(),
         event_tx: event_tx.clone(),
         comfyui_client_id: comfyui_client_id.clone(),
+        prompt_optimizer: PromptOptimizer::new(),
         config: config.clone(),
     };
 

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -42,6 +42,9 @@ pub struct GenerateRequest {
     /// Batch size
     #[serde(default = "default_batch_size")]
     pub batch_size: u32,
+    /// LoRA configurations
+    #[serde(default)]
+    pub loras: Vec<LoraConfig>,
     /// HiFix enabled
     #[serde(default)]
     pub hifix_enabled: bool,
@@ -66,6 +69,42 @@ pub struct GenerateRequest {
     /// HiFix upscale method
     #[serde(default = "default_hifix_upscale_method")]
     pub hifix_upscale_method: String,
+}
+
+/// LoRA configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoraConfig {
+    /// LoRA file name
+    pub name: String,
+    /// LoRA strength (-4.0 to 4.0)
+    #[serde(default = "default_lora_strength")]
+    pub strength: f32,
+}
+
+fn default_lora_strength() -> f32 {
+    1.0
+}
+
+/// Prompt optimization request (Gemma + Jina CLIP rerank)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OptimizePromptRequest {
+    /// User handwritten prompt (any language)
+    pub prompt: String,
+    /// Optional additional tags (raw text)
+    #[serde(default)]
+    pub tags: String,
+    /// Optional reference image as a data URL (data:image/...;base64,...) or bare base64
+    #[serde(default)]
+    pub reference_image: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OptimizePromptResponse {
+    /// Final JSON string (includes XML in image.tags) that should replace the user's prompt
+    pub optimized_prompt: String,
+    /// Optional extra candidates for UI preview
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub candidates: Option<Vec<String>>,
 }
 
 fn default_width() -> u32 {

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -1,0 +1,1 @@
+pub mod prompt_optimizer;

--- a/backend/src/services/prompt_optimizer.rs
+++ b/backend/src/services/prompt_optimizer.rs
@@ -1,0 +1,31 @@
+use crate::error::AppResult;
+use crate::models::{OptimizePromptRequest, OptimizePromptResponse};
+
+/// Minimal prompt optimizer stub.
+#[derive(Clone, Default)]
+pub struct PromptOptimizer;
+
+impl PromptOptimizer {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub async fn optimize(
+        &self,
+        request: OptimizePromptRequest,
+    ) -> AppResult<OptimizePromptResponse> {
+        let mut optimized_prompt = request.prompt;
+        let tags = request.tags.trim();
+        if !tags.is_empty() {
+            if !optimized_prompt.is_empty() {
+                optimized_prompt.push('\n');
+            }
+            optimized_prompt.push_str(tags);
+        }
+
+        Ok(OptimizePromptResponse {
+            optimized_prompt,
+            candidates: None,
+        })
+    }
+}


### PR DESCRIPTION
Summary
- CN: 增加 LoRA workflow 支持（启用参数与路径转换），并接入最小 PromptOptimizer stub 以保持 /api/prompt/optimize 可用。
- EN: Add LoRA workflow support (enable flag and path normalization) and wire a minimal PromptOptimizer stub to keep /api/prompt/optimize available.

Testing
- CN: cargo check (backend)
- EN: cargo check (backend)

Risk
- CN: 低；新增后端参数与 stub 接口，需确认与现有工作流兼容。
- EN: Low; adds backend parameters and a stub endpoint, verify workflow compatibility.