### PR TITLE
fix(repo): close lora list block and ignore release output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ CLAUDE.md
 backend/target/
 frontend/dist/
 frontend/node_modules/
+release/
 
 # Executables
 *.exe

--- a/backend/src/comfyui.rs
+++ b/backend/src/comfyui.rs
@@ -640,7 +640,8 @@ fn extract_lora_list_from_section(section: Option<&Value>) -> Option<Vec<String>
     for field in ["lora_name", "lora_names"] {
         if let Some(field_value) = section.get(field) {
             if let Some(list) = extract_lora_list_from_field(field_value) {
-            return Some(list);
+                return Some(list);
+            }
         }
     }
     None


### PR DESCRIPTION
## Summary
EN:
- Fix missing brace in LoRA list extraction to resolve compile error.
- Ignore `release/` build outputs in `.gitignore`.

CN:
- 修复 LoRA 列表解析中缺失的大括号，解决编译错误。
- 在 `.gitignore` 中忽略 `release/` 构建产物。

## Testing
EN:
- `cargo check` (backend)

CN:
- `cargo check`（backend）

## Risk
EN:
- Low; minimal logic and ignore-rule changes.

CN:
- 低；小范围逻辑与忽略规则调整。